### PR TITLE
Fix so that it can be bound to an object/field and display existing values

### DIFF
--- a/handlers/formcontrols/multiSelect.cfc
+++ b/handlers/formcontrols/multiSelect.cfc
@@ -37,8 +37,7 @@ component {
 		if ( args.multiple ) {
 			var sourceObject  = args.sourceObject ?: "";
 			var sourceIdField = presideObjectService.getIdField( sourceObject );
-			args.object       = args.relatedTo ?: "";
-			var targetIdField = presideObjectService.getIdField( args.object );
+			var targetIdField = presideObjectService.getIdField( args.relatedTo ?: "" );
 
 			if (  Len( Trim( args.savedData[ sourceIdField ] ?: "" ) ) ) {
 				var useVersioning = Val( rc.version ?: "" ) && presideObjectService.objectIsVersioned( sourceObject );

--- a/handlers/formcontrols/multiSelect.cfc
+++ b/handlers/formcontrols/multiSelect.cfc
@@ -31,30 +31,31 @@ component {
 		}
 
 
-		var sourceObject  = args.sourceObject ?: "";
-		var sourceIdField = presideObjectService.getIdField( sourceObject );
 
-		args.object   = args.relatedTo ?: "";
 		args.multiple = args.multiple ?: true;
 
-		var targetIdField = presideObjectService.getIdField( args.object );
+		if ( args.multiple ) {
+			var sourceObject  = args.sourceObject ?: "";
+			var sourceIdField = presideObjectService.getIdField( sourceObject );
+			args.object       = args.relatedTo ?: "";
+			var targetIdField = presideObjectService.getIdField( args.object );
 
-		if ( args.multiple && Len( Trim( args.savedData[ sourceIdField ] ?: "" ) ) ) {
-			var useVersioning = Val( rc.version ?: "" ) && presideObjectService.objectIsVersioned( sourceObject );
+			if (  Len( Trim( args.savedData[ sourceIdField ] ?: "" ) ) ) {
+				var useVersioning = Val( rc.version ?: "" ) && presideObjectService.objectIsVersioned( sourceObject );
 
-			args.savedValue = presideObjectService.selectManyToManyData(
-				  objectName       = sourceObject
-				, propertyName     = args.name
-				, id               = args.savedData[ sourceIdField ]
-				, selectFields     = [ "#args.name#.#targetIdField# as id" ]
-				, useCache         = false
-				, fromVersionTable = useVersioning
-				, specificVersion  = Val( rc.version ?: "" )
-			);
+				args.savedValue = presideObjectService.selectManyToManyData(
+					  objectName       = sourceObject
+					, propertyName     = args.name
+					, id               = args.savedData[ sourceIdField ]
+					, selectFields     = [ "#args.name#.#targetIdField# as id" ]
+					, useCache         = false
+					, fromVersionTable = useVersioning
+					, specificVersion  = Val( rc.version ?: "" )
+				);
 
-			args.defaultValue = args.savedValue = ValueList( args.savedValue.id );
+				args.defaultValue = args.savedValue = ValueList( args.savedValue.id );
+			}
 		}
-
 
 		event.include( "ext-multi-select" );
 

--- a/handlers/formcontrols/multiSelect.cfc
+++ b/handlers/formcontrols/multiSelect.cfc
@@ -35,11 +35,11 @@ component {
 		var sourceIdField = presideObjectService.getIdField( sourceObject );
 
 		args.object   = args.relatedTo ?: "";
-		args.multiple = true;
+		args.multiple = args.multiple ?: true;
 
 		var targetIdField = presideObjectService.getIdField( args.object );
 
-		if ( Len( Trim( args.savedData[ sourceIdField ] ?: "" ) ) ) {
+		if ( args.multiple && Len( Trim( args.savedData[ sourceIdField ] ?: "" ) ) ) {
 			var useVersioning = Val( rc.version ?: "" ) && presideObjectService.objectIsVersioned( sourceObject );
 
 			args.savedValue = presideObjectService.selectManyToManyData(

--- a/handlers/formcontrols/multiSelect.cfc
+++ b/handlers/formcontrols/multiSelect.cfc
@@ -30,6 +30,32 @@ component {
 			args.labels = ValueArray( args.records.label );
 		}
 
+
+		var sourceObject  = args.sourceObject ?: "";
+		var sourceIdField = presideObjectService.getIdField( sourceObject );
+
+		args.object   = args.relatedTo ?: "";
+		args.multiple = true;
+
+		var targetIdField = presideObjectService.getIdField( args.object );
+
+		if ( Len( Trim( args.savedData[ sourceIdField ] ?: "" ) ) ) {
+			var useVersioning = Val( rc.version ?: "" ) && presideObjectService.objectIsVersioned( sourceObject );
+
+			args.savedValue = presideObjectService.selectManyToManyData(
+				  objectName       = sourceObject
+				, propertyName     = args.name
+				, id               = args.savedData[ sourceIdField ]
+				, selectFields     = [ "#args.name#.#targetIdField# as id" ]
+				, useCache         = false
+				, fromVersionTable = useVersioning
+				, specificVersion  = Val( rc.version ?: "" )
+			);
+
+			args.defaultValue = args.savedValue = ValueList( args.savedValue.id );
+		}
+
+
 		event.include( "ext-multi-select" );
 
 		if ( includeChosenJs ) {


### PR DESCRIPTION
You can now use the binding on the field so it displays any existing values e.g. 
_<field binding="crm_organisation.accreditations" control="multiSelect" object="crm_accreditation" />_
Have just copied the code from the existing preside ManyToManySelect.cfc handler 