### PR TITLE
ELF-415 multiselect selected child option not updated on fe

### DIFF
--- a/assets/js/specific/multiSelect/multi-select.js
+++ b/assets/js/specific/multiSelect/multi-select.js
@@ -19,7 +19,7 @@ var pixl8presideExtMultiselect = function() {
 			var selectedChildValue = $selectChild.val();
 
 			if ( selectedChildValue && !$.isArray( selectedChildValue ) ) {
-				selectedChildValue.split( "," );
+				selectedChildValue = selectedChildValue.split( "," );
 			}
 
 			var filterByField = $selectChild.data( 'filter-by' );


### PR DESCRIPTION
On line 22: `selectedChildValue.split( "," );`
- the defined variable **selectedChildValue** is not updated to array

Which result in line 43 to always return false and no option is marked as selected
- Line 43 `if ( selectedChildValue && $.inArray( String(data[i].id), selectedChildValue ) > -1 ) {`

Update on line 22 to resolve this:
- `selectedChildValue = selectedChildValue.split( "," );`