### PR TITLE
Custom filter params setting for type-to-search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.2.1
+* Remove ajax type-to-search default url from cfrequest
+* Allow custom filter for type-to-search, used in pair with custom pixl8presideExtMultiselect.fn.updateChildSelect
+* Convert filter values to list
+
 ## v1.2.0
 
 * Update asset build (minifying assets)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This extension provides multi select form control with AJAX filtering functionality binding to Preside data objects. See [Wiki](https://github.com/pixl8/preside-ext-multiselect/wiki) for complete usage documentation.
+This extension provides multi select form control with AJAX filtering functionality binding to Preside data objects.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,47 @@ box install preside-ext-multiselect
 ```
 
 Reload your application
+
+## Install the Preside extension (Static)
+1. Add `extensions` folder if not already
+2. Install the submodule from project root: `git submodule add -b stable https://github.com/pixl8/preside-ext-multiselect.git static/extensions/preside-ext-multiselect`
+3. Within `Application.cfc`, add the following lines:
+4. * `this.mappings[ "/extensions" ] = ExpandPath( "/extensions" );`
+5. * `sticker.addBundle( "/extensions/preside-ext-multiselect/assets", "/extensions/preside-ext-multiselect/assets" );`
+6. Anywhere within `.cfm` file that uses multiple select field, define `sticker.include( "ext-custom-chosen" );` at the top of the file
+
+## Install the Preside extension (Web)
+1. Install and enable the extension
+
+### Ajax filtering setup
+#### Sample usage for form field xml definition
+
+    <field name="parent_field_name" control="multiSelect" object="parent_db_object" filterChildId="related_child_select_field_name" ajax="/formcontrols/MultiSelect/refreshChildOptions/" extraClass="select-filter-by"/>
+
+    <field name="related_child_select_field_name"  control="multiSelect" object="child_db_object" filterBy="db_field_link_to_parent" objectFilters="activeOnly" />
+
+#### Form attributes definition
+| Attribute name  | Value  | Usage  |
+|---|---|---|
+| control  | multiSelect  |  |
+| object  | Variable: DB object name |   |
+| filterChildId  |   | Required for parent field. This could be a list of child field names  |
+| ajax | /formcontrols/MultiSelect/refreshChildOptions/ | Ajax URL to post to |
+| extraClass | select-filter-by | Required for parent field. |
+| filterBy | Variable: FK within child DB object  | Required for child field. FK within the child DB object that links to the parent table |
+
+### Ajax type-to-search setup
+Useful for `select` with huge list of options to limit a fix number of result on load, and type-to-search to bring up further matching options
+#### Sample usage for form field xml definition
+    <field name="field_custom" ... />
+    <field name="field_with_long_options" control="multiSelect" ...  ajaxMaxRows="10" ajaxTextSearch="1" ajaxSearchCustomFilter="..." ajaxSearchUrl="..." />
+
+
+#### Form attributes definition
+| Attribute name  | Value  | Usage  |
+|---|---|---|
+| control  | multiSelect  |  |
+| ajaxMaxRows | /formcontrols/MultiSelect/refreshChildOptions/ | Max rows of options to be loaded (pre-selected values are not counted in this number) |
+| ajaxTextSearch | 1 | Flag control to use Ajax text search |
+| ajaxSearchCustomFilter | field_custom | Additional form control ID for type-to-search custom filtering (other than filterChildId / filterBy relationship). Could be a comma-separated list |
+| ajaxSearchUrl | | Custom type-to-search post URL - to be used together with ajaxSearchCustomFilter. If not specified, the default value is /formcontrols/MultiSelect/getObjectRecordsForAjaxSelectControl/ |

--- a/assets/js/specific/ajaxTextObjectRecSearch/ajax-text-search.js
+++ b/assets/js/specific/ajaxTextObjectRecSearch/ajax-text-search.js
@@ -15,17 +15,17 @@
 
 			if ( this.value.length >= 2 && ( ( e.keyCode >= 48 && e.keyCode <= 90 ) || e.keyCode == 8 ) ) {
 
-				var searchUrl       = cfrequest.searchTermUrl;
-				var customSearchUrl = $selectField.data( 'ajax-search-url' );
+				var searchUrl = $selectField.data( 'ajax-search-url' );
 
 				var params = {};
-				params[ 'searchTerm'    ] = this.value;
-				params[ 'filterBy'      ] = $selectField.data( 'filter-by' );
-				params[ 'targetObject'  ] = $selectField.data( 'object' );
-				params[ 'dbFilters'     ] = $selectField.data( 'object-filters' );
-				params[ 'orderBy'       ] = $selectField.data( 'order-by' );
-				params[ 'maxRows'       ] = $selectField.data( 'ajax-maxrows' );
-				params[ 'ajaxTxtSearch' ] = $selectField.data( 'ajax-txt-search' );
+				params[ 'searchTerm'    ]          = this.value;
+				params[ 'filterBy'      ]          = $selectField.data( 'filter-by' );
+				params[ 'targetObject'  ]          = $selectField.data( 'object' );
+				params[ 'dbFilters'     ]          = $selectField.data( 'object-filters' );
+				params[ 'orderBy'       ]          = $selectField.data( 'order-by' );
+				params[ 'maxRows'       ]          = $selectField.data( 'ajax-maxrows' );
+				params[ 'ajaxTxtSearch' ]          = $selectField.data( 'ajax-txt-search' );
+				params[ 'ajaxSearchCustomFilter' ] = $selectField.data( "ajax-custom-filter" );
 
 				// for child select, get parent selected value for filtering
 				if ( typeof params[ 'filterBy' ] != 'undefined' ) {
@@ -36,8 +36,13 @@
 					params[ filterByField  ] = selectedParentVal;
 				}
 
-				if ( typeof customSearchUrl != 'undefined' && customSearchUrl.length ) {
-					searchUrl = customSearchUrl;
+				// get custom id values for params
+				if ( typeof params[ 'ajaxSearchCustomFilter' ] != 'undefined' ) {
+					var customSearchFilter = params[ 'ajaxSearchCustomFilter' ].split( "," );
+
+					$.each( customSearchFilter, function( index, value ) {
+						params[ value ] = $( '#' + value ).val();
+					} );
 				}
 
 				$.ajax({

--- a/assets/js/specific/ajaxTextObjectRecSearch/ajax-text-search.js
+++ b/assets/js/specific/ajaxTextObjectRecSearch/ajax-text-search.js
@@ -33,6 +33,10 @@
 
 					var selectedParentVal = $('select[data-filter-child-id*="'+ $selectField.attr( "id" ) +'"]').val();
 
+					if ( selectedParentVal && $.isArray( selectedParentVal ) ) {
+						selectedParentVal = selectedParentVal.join( "," );
+					}
+
 					params[ filterByField  ] = selectedParentVal;
 				}
 

--- a/assets/js/specific/multiSelect/multi-select.js
+++ b/assets/js/specific/multiSelect/multi-select.js
@@ -25,13 +25,14 @@ var pixl8presideExtMultiselect = function() {
 			var filterByField = $selectChild.data( 'filter-by' );
 
 			var data = {};
-			data[ filterByField   ] = selectedParent;
-			data[ 'filterBy'      ] = $selectChild.data( 'filter-by' );
-			data[ 'targetObject'  ] = $selectChild.data( 'object' );
-			data[ 'dbFilters'     ] = $selectChild.data( 'object-filters' );
-			data[ 'orderBy'       ] = $selectChild.data( 'order-by' );
-			data[ 'maxRows'       ] = $selectChild.data( 'ajax-maxrows' );
-			data[ 'ajaxTxtSearch' ] = $selectChild.data( 'ajax-txt-search' );
+			data[ filterByField   ]          = selectedParent;
+			data[ 'filterBy'      ]          = $selectChild.data( 'filter-by' );
+			data[ 'targetObject'  ]          = $selectChild.data( 'object' );
+			data[ 'dbFilters'     ]          = $selectChild.data( 'object-filters' );
+			data[ 'orderBy'       ]          = $selectChild.data( 'order-by' );
+			data[ 'maxRows'       ]          = $selectChild.data( 'ajax-maxrows' );
+			data[ 'ajaxTxtSearch' ]          = $selectChild.data( 'ajax-txt-search' );
+			data[ 'ajaxSearchCustomFilter' ] = $selectChild.data( "ajax-custom-filter" );
 
 			// if ajax txt search enabled, check pre-selected value (might not be in the option list on first page)
 			if ( typeof data[ 'ajaxTxtSearch' ] != 'undefined' && typeof data[ 'maxRows' ] != 'undefined' ) {

--- a/handlers/formcontrols/multiSelect.cfc
+++ b/handlers/formcontrols/multiSelect.cfc
@@ -16,19 +16,21 @@ component {
 		var filterByField    = args.filterByField ?: filterBy;
 		var selectFields     = [ "id",labelField & " as label" ];
 
-		var ajaxTxtSearch    = IsTrue( args.ajaxTextSearch ?: "" );
-		var fieldName        = args.name ?: "";
-		var maxRows          = ajaxTxtSearch ? ( args.ajaxMaxRows ?: 0 ) : 0;
-		var selectUnion      = false;
+		var ajaxTxtSearch          = IsTrue( args.ajaxTextSearch ?: "" );
+		var fieldName              = args.name ?: "";
+		var maxRows                = ajaxTxtSearch ? ( args.ajaxMaxRows ?: 0 ) : 0;
+		var selectUnion            = false;
+		var ajaxSearchCustomFilter = args.ajaxSearchCustomFilter ?: "";
 
 		multiSelectAllowListService.addToAllowList(
-			  targetObject  = object
-			, filterBy      = filterBy
-			, filterByField = filterByField
-			, orderBy       = orderBy
-			, dbFilters     = savedFilters
-			, maxRows       = maxRows
-			, ajaxTxtSearch = ajaxTxtSearch
+			  targetObject           = object
+			, filterBy               = filterBy
+			, filterByField          = filterByField
+			, orderBy                = orderBy
+			, dbFilters              = savedFilters
+			, maxRows                = maxRows
+			, ajaxTxtSearch          = ajaxTxtSearch
+			, ajaxSearchCustomFilter = ajaxSearchCustomFilter
 		);
 
 		if( len( valueField ) ) {
@@ -106,8 +108,11 @@ component {
 				args.defaultValue = args.savedValue = ValueList( args.savedValue.id );
 			}
 		} else if ( Len( object ) && !defaultEmptyList && ajaxTxtSearch && maxRows ) {
-			event.include( "/js/specific/ajaxTextObjectRecSearch/" )
-				.includeData( { searchTermUrl= event.buildLink( linkTo = "formcontrols.multiselect.getObjectRecordsForAjaxSelectControl" ) } );
+			event.include( "/js/specific/ajaxTextObjectRecSearch/" );
+
+			if ( !Len( args.ajaxSearchUrl ?: "" ) ) {
+				args.ajaxSearchUrl = event.buildLink( linkTo = "formcontrols.multiselect.getObjectRecordsForAjaxSelectControl" );
+			}
 		}
 
 		event.include( "/js/specific/multiSelect/" );

--- a/services/MultiSelectAllowListService.cfc
+++ b/services/MultiSelectAllowListService.cfc
@@ -13,13 +13,14 @@ component {
 
 // PUBLIC API METHODS
 	public void function addToAllowList(
-		  string targetObject   = ""
-		, string filterBy       = ""
-		, string filterByField  = ""
-		, string orderBy        = ""
-		, string dbFilters      = ""
-		, numeric maxRows       = 0
-		, boolean ajaxTxtSearch = false
+		  string targetObject           = ""
+		, string filterBy               = ""
+		, string filterByField          = ""
+		, string orderBy                = ""
+		, string dbFilters              = ""
+		, numeric maxRows               = 0
+		, boolean ajaxTxtSearch         = false
+		, string ajaxSearchCustomFilter = ""
 	) {
 		var cacheKey = _getCacheKey( argumentCollection=arguments );
 
@@ -29,28 +30,29 @@ component {
 	}
 
 	public boolean function isParameterCombinationAllowed(
-		  string targetObject   = ""
-		, string filterBy       = ""
-		, string filterByField  = ""
-		, string orderBy        = ""
-		, string dbFilters      = ""
-		, numeric maxRows       = 0
-		, boolean ajaxTxtSearch = false
+		  string targetObject           = ""
+		, string filterBy               = ""
+		, string filterByField          = ""
+		, string orderBy                = ""
+		, string dbFilters              = ""
+		, numeric maxRows               = 0
+		, boolean ajaxTxtSearch         = false
+		, string ajaxSearchCustomFilter = ""
 	) {
 		return variables._allowListCache[ _getCacheKey( argumentCollection=arguments ) ] ?: false;
 	}
 
 // PRIVATE HELPERS
 	private string function _getCacheKey(
-		  string targetObject   = ""
-		, string filterBy       = ""
-		, string filterByField  = ""
-		, string orderBy        = ""
-		, string dbFilters      = ""
-		, numeric maxRows       = 0
-		, boolean ajaxTxtSearch = false
+		  string targetObject           = ""
+		, string filterBy               = ""
+		, string filterByField          = ""
+		, string orderBy                = ""
+		, string dbFilters              = ""
+		, numeric maxRows               = 0
+		, boolean ajaxTxtSearch         = false
+		, string ajaxSearchCustomFilter = ""
 	) {
-		return "targetObject:#arguments.targetObject#,filterBy:#arguments.filterBy#,filterByField:#arguments.filterByField#,orderBy:#arguments.orderBy#,dbFilters:#arguments.dbFilters#,maxRows:#arguments.maxRows#,ajaxTxtSearch=#arguments.ajaxTxtSearch#";
+		return "targetObject:#arguments.targetObject#,filterBy:#arguments.filterBy#,filterByField:#arguments.filterByField#,orderBy:#arguments.orderBy#,dbFilters:#arguments.dbFilters#,maxRows:#arguments.maxRows#,ajaxTxtSearch=#arguments.ajaxTxtSearch#,ajaxSearchCustomFilter=#arguments.ajaxSearchCustomFilter#";
 	}
-
 }

--- a/services/MultiSelectFormControlService.cfc
+++ b/services/MultiSelectFormControlService.cfc
@@ -15,43 +15,46 @@ component {
 
 	public struct function processRequestParamsForSelect( required struct reqContext ) {
 		return {
-			  targetObject  = arguments.reqContext.targetObject  ?: ""
-			, filterBy      = arguments.reqContext.filterBy      ?: ""
-			, filterByField = arguments.reqContext.filterByField ?: ( arguments.reqContext.filterBy ?: "" )
-			, orderBy       = arguments.reqContext.orderBy       ?: "label"
-			, dbFilters     = arguments.reqContext.dbFilters     ?: ""
-			, maxRows       = arguments.reqContext.maxRows       ?: 0
-			, searchTerm    = arguments.reqContext.searchTerm    ?: ""
-			, ajaxTxtSearch = $helpers.isTrue( arguments.reqContext.ajaxTxtSearch ?: 0 )
+			  targetObject          = arguments.reqContext.targetObject  ?: ""
+			, filterBy              = arguments.reqContext.filterBy      ?: ""
+			, filterByField         = arguments.reqContext.filterByField ?: ( arguments.reqContext.filterBy ?: "" )
+			, orderBy               = arguments.reqContext.orderBy       ?: "label"
+			, dbFilters             = arguments.reqContext.dbFilters     ?: ""
+			, maxRows               = arguments.reqContext.maxRows       ?: 0
+			, searchTerm            = arguments.reqContext.searchTerm    ?: ""
+			, ajaxTxtSearch         = $helpers.isTrue( arguments.reqContext.ajaxTxtSearch ?: 0 )
+			, ajaxSearchCustomFilter = arguments.reqContext.ajaxSearchCustomFilter    ?: ""
 		};
 	}
 
 	public boolean function isAjaxRequestAllowed( required struct preparedParams, boolean textSearch = false ) {
-		var targetObject  = arguments.preparedParams.targetObject;
-		var filterBy      = arguments.preparedParams.filterBy;
-		var filterByField = arguments.preparedParams.filterByField;
-		var orderBy       = arguments.preparedParams.orderBy;
-		var dbFilters     = arguments.preparedParams.dbFilters;
-		var maxRows       = arguments.preparedParams.maxRows;
-		var searchTerm    = arguments.preparedParams.searchTerm;
-		var ajaxTxtSearch = arguments.preparedParams.ajaxTxtSearch;
+		var targetObject           = arguments.preparedParams.targetObject;
+		var filterBy               = arguments.preparedParams.filterBy;
+		var filterByField          = arguments.preparedParams.filterByField;
+		var orderBy                = arguments.preparedParams.orderBy;
+		var dbFilters              = arguments.preparedParams.dbFilters;
+		var maxRows                = arguments.preparedParams.maxRows;
+		var searchTerm             = arguments.preparedParams.searchTerm;
+		var ajaxTxtSearch          = arguments.preparedParams.ajaxTxtSearch;
+		var ajaxSearchCustomFilter = arguments.preparedParams.ajaxSearchCustomFilter
 
 		if ( !Len( Trim( targetObject ) ) ||
 			( arguments.textSearch && !ajaxTxtSearch ) ||
 				( ajaxTxtSearch && !maxRows ) ||
 					( arguments.textSearch && !Len( searchTerm ) )
-		 ) {
-		 	return false;
+		) {
+			return false;
 		}
 
 		var requestAllowed = _getMultiSelectAllowListService().isParameterCombinationAllowed(
-			  targetObject  = targetObject
-			, filterBy      = filterBy
-			, filterByField = filterByField
-			, orderBy       = orderBy
-			, dbFilters     = dbFilters
-			, maxRows       = maxRows
-			, ajaxTxtSearch = ajaxTxtSearch
+			  targetObject           = targetObject
+			, filterBy               = filterBy
+			, filterByField          = filterByField
+			, orderBy                = orderBy
+			, dbFilters              = dbFilters
+			, maxRows                = maxRows
+			, ajaxTxtSearch          = ajaxTxtSearch
+			, ajaxSearchCustomFilter = ajaxSearchCustomFilter
 		);
 
 		if ( !requestAllowed ) {

--- a/views/formcontrols/multiSelect/index.cfm
+++ b/views/formcontrols/multiSelect/index.cfm
@@ -8,19 +8,20 @@
 	extraClass         = args.extraClass       ?: "";
 	placeholder        = args.placeholder      ?: "";
 	// ajax filter options
-	filterChildId      = args.filterChildId    ?: "";
-	ajax               = args.ajax             ?: "";
-	filterBy           = args.filterBy         ?: "";
-	object             = args.object           ?: "";
-	objectFilters      = args.objectFilters    ?: "";
-	multiple           = args.multiple         ?: true;
-	maxSelected        = args.maxSelected      ?: "";
-	orderBy            = args.orderBy          ?: "label";
-	allowDeselect      = args.allowDeselect    ?: false;
-	sortable           = args.sortable         ?: false;
-	ajaxTextSearch     = args.ajaxTextSearch   ?: false;
-	ajaxMaxRows        = args.ajaxMaxRows      ?: 0;
-	ajaxSearchUrl      = args.ajaxSearchUrl    ?: "";
+	filterChildId          = args.filterChildId          ?: "";
+	ajax                   = args.ajax                   ?: "";
+	filterBy               = args.filterBy               ?: "";
+	object                 = args.object                 ?: "";
+	objectFilters          = args.objectFilters          ?: "";
+	multiple               = args.multiple               ?: true;
+	maxSelected            = args.maxSelected            ?: "";
+	orderBy                = args.orderBy                ?: "label";
+	allowDeselect          = args.allowDeselect          ?: false;
+	sortable               = args.sortable               ?: false;
+	ajaxTextSearch         = args.ajaxTextSearch         ?: false;
+	ajaxMaxRows            = args.ajaxMaxRows            ?: 0;
+	ajaxSearchUrl          = args.ajaxSearchUrl          ?: "";
+	ajaxSearchCustomFilter = args.ajaxSearchCustomFilter ?: "";
 
 	if ( IsSimpleValue( values ) ) { values = ListToArray( values ); }
 	if ( IsSimpleValue( labels ) ) { labels = ListToArray( labels ); }
@@ -67,6 +68,8 @@
 		data-ajax-maxrows="#ajaxMaxRows#"
 	</cfif><cfif Len( ajaxSearchUrl )>
 		data-ajax-search-url="#ajaxSearchUrl#"
+	</cfif><cfif Len( ajaxSearchCustomFilter )>
+		data-ajax-custom-filter="#ajaxSearchCustomFilter#"
 	</cfif>>
 		<cfloop array="#values#" index="i" item="selectValue">
 			<cfset isSelectedValue = ListFindNoCase( value, selectValue ) />


### PR DESCRIPTION
* Remove ajax type-to-search default url from cfrequest
* Allow custom filter for type-to-search, used in pair with custom pixl8presideExtMultiselect.fn.updateChildSelect
* Convert filter values to list