### PR TITLE
Fix issue with empty options in native rendering

### DIFF
--- a/views/formcontrols/multiSelect/index.cfm
+++ b/views/formcontrols/multiSelect/index.cfm
@@ -77,9 +77,9 @@
 	</cfif><cfif disabled>
 		disabled="disabled"
 	</cfif>>
+		<cfif isTrue( allowDeselect )><option value=""></option></cfif>
 		<cfloop array="#values#" index="i" item="selectValue">
 			<cfset isSelectedValue = ListFindNoCase( value, selectValue ) />
-			<cfif isTrue( allowDeselect )><option value=""></option></cfif>
 			<option value="#HtmlEditFormat( selectValue )#"
 				<cfif isSelectedValue || (!len(value) && labels[i]==defaultLabel ) > selected="selected"</cfif>
 			>#HtmlEditFormat( translateResource( labels[i] ?: "", labels[i] ?: "" ) )#</option>


### PR DESCRIPTION
When the select is rendered on mobile empty options appear between every valid option. This should fix that behaviour.