### PR TITLE
PXMULTISEL-22: Enhance multiSelect component by adding labelRenderer …

### DIFF
--- a/handlers/formcontrols/multiSelect.cfc
+++ b/handlers/formcontrols/multiSelect.cfc
@@ -208,13 +208,14 @@ component {
 		var selectFields = _prepareSelectFields( rc );
 
 		var records = datamanagerService.getRecordsForAjaxSelect(
-			  objectName   = preparedParams.targetObject
-			, selectFields = selectFields
-			, savedFilters = ListToArray( preparedParams.dbFilters )
-			, searchQuery  = preparedParams.searchTerm
-			, extraFilters = extraFilters
-			, maxRows      = preparedParams.maxRows
-			, orderBy      = preparedParams.orderBy
+			  objectName    = preparedParams.targetObject
+			, selectFields  = selectFields
+			, savedFilters  = ListToArray( preparedParams.dbFilters )
+			, searchQuery   = preparedParams.searchTerm
+			, extraFilters  = extraFilters
+			, maxRows       = preparedParams.maxRows
+			, orderBy       = preparedParams.orderBy
+			, labelRenderer = rc.labelRenderer ?: ""
 		);
 
 		event.renderData( type="json", data=records );

--- a/handlers/formcontrols/multiSelect.cfc
+++ b/handlers/formcontrols/multiSelect.cfc
@@ -215,7 +215,7 @@ component {
 			, extraFilters  = extraFilters
 			, maxRows       = preparedParams.maxRows
 			, orderBy       = preparedParams.orderBy
-			, labelRenderer = preparedParams.labelRenderer ?: ( rc.labelRenderer ?: "" )
+			, labelRenderer = presideObjectService.getObjectAttribute( preparedParams.targetObject, "labelRenderer" )
 		);
 
 		event.renderData( type="json", data=records );

--- a/handlers/formcontrols/multiSelect.cfc
+++ b/handlers/formcontrols/multiSelect.cfc
@@ -215,7 +215,7 @@ component {
 			, extraFilters  = extraFilters
 			, maxRows       = preparedParams.maxRows
 			, orderBy       = preparedParams.orderBy
-			, labelRenderer = rc.labelRenderer ?: ""
+			, labelRenderer = preparedParams.labelRenderer ?: ( rc.labelRenderer ?: "" )
 		);
 
 		event.renderData( type="json", data=records );

--- a/services/MultiSelectFormControlService.cfc
+++ b/services/MultiSelectFormControlService.cfc
@@ -24,7 +24,6 @@ component {
 			, searchTerm            = arguments.reqContext.searchTerm    ?: ""
 			, ajaxTxtSearch         = $helpers.isTrue( arguments.reqContext.ajaxTxtSearch ?: 0 )
 			, ajaxSearchCustomFilter = arguments.reqContext.ajaxSearchCustomFilter    ?: ""
-			, labelRenderer          = arguments.reqContext.labelRenderer             ?: ""
 		};
 	}
 

--- a/services/MultiSelectFormControlService.cfc
+++ b/services/MultiSelectFormControlService.cfc
@@ -24,6 +24,7 @@ component {
 			, searchTerm            = arguments.reqContext.searchTerm    ?: ""
 			, ajaxTxtSearch         = $helpers.isTrue( arguments.reqContext.ajaxTxtSearch ?: 0 )
 			, ajaxSearchCustomFilter = arguments.reqContext.ajaxSearchCustomFilter    ?: ""
+			, labelRenderer          = arguments.reqContext.labelRenderer             ?: ""
 		};
 	}
 


### PR DESCRIPTION
…parameter to getRecordsForAjaxSelect method

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `labelRenderer` request parameter and forwards it to `getRecordsForAjaxSelect`, affecting only multiSelect AJAX search label formatting.
> 
> **Overview**
> Enables the multiSelect AJAX text-search endpoint to accept an optional `labelRenderer` parameter and forward it into `datamanagerService.getRecordsForAjaxSelect`, allowing callers to control how record labels are rendered.
> 
> `MultiSelectFormControlService.processRequestParamsForSelect()` now captures `labelRenderer` from the request, and `handlers/formcontrols/multiSelect.cfc#getObjectRecordsForAjaxSelectControl` passes it through (falling back to `rc.labelRenderer`/empty string).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6174fcff61b22d6c6717189490f8292525d42889. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->