### PR TITLE
PXMULTISEL-23 use database stored cache key instead

### DIFF
--- a/preside-objects/multiselect_allow_list.cfc
+++ b/preside-objects/multiselect_allow_list.cfc
@@ -1,0 +1,10 @@
+/**
+ * @versioned          false
+ * @nolabel            true
+ * @nodatemodified     true
+ * @nodatecreated      true
+ * @datamanagerEnabled false
+ */
+component {
+	property name="id" type="string" dbtype="varchar" maxlength=32 generator="none" required=true;
+}

--- a/services/MultiSelectAllowListService.cfc
+++ b/services/MultiSelectAllowListService.cfc
@@ -4,8 +4,6 @@
  */
 component {
 
-	variables._allowListCache = {};
-
 // CONSTRUCTOR
 	public any function init() {
 		return this;
@@ -22,10 +20,14 @@ component {
 		, boolean ajaxTxtSearch         = false
 		, string ajaxSearchCustomFilter = ""
 	) {
-		var cacheKey = _getCacheKey( argumentCollection=arguments );
+		var hashedCacheKey = Hash( _getCacheKey( argumentCollection=arguments ) );
 
-		if ( !StructKeyExists( variables._allowListCache, cacheKey ) ) {
-			variables._allowListCache[ cacheKey ] = true;
+		try {
+			$getPresideObject( "multiselect_allow_list" ).insertData( data={ id=hashedCacheKey } );
+		} catch ( database e ) {
+			if ( !$getPresideObject( "multiselect_allow_list" ).dataExists( id=hashedCacheKey, useCache=false ) ) {
+				rethrow;
+			}
 		}
 	}
 
@@ -39,7 +41,9 @@ component {
 		, boolean ajaxTxtSearch         = false
 		, string ajaxSearchCustomFilter = ""
 	) {
-		return variables._allowListCache[ _getCacheKey( argumentCollection=arguments ) ] ?: false;
+		var hashedCacheKey = Hash( _getCacheKey( argumentCollection=arguments ) );
+
+		return $getPresideObject( "multiselect_allow_list" ).dataExists( id=hashedCacheKey, useCache=false );
 	}
 
 // PRIVATE HELPERS


### PR DESCRIPTION
The allow-list was stored in a component-scoped in-memory struct, local to a single app server pod/JVM. In a multi-pod deployment, if the page render and the subsequent AJAX search land on different pods (routing, redeploy, pod restart), the second pod's cache never saw the registration, so the check fails and the request is rejected with a 403.

**Fix applied**
Replaced the in-memory struct with a DB-backed preside object, so the allow-list is shared across all pods/instances regardless of which one served the render vs. the search.